### PR TITLE
Use new unsafe idom to replace use of deprecated reflect.SliceHeader

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -42,10 +42,10 @@ import (
 	"unsafe"
 
 	"github.com/google/deck"
-	"golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/cryptobyte"
-	"golang.org/x/sys/windows"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
 )
 
 // WinCertStorage provides windows-specific additions to the CertStorage interface.
@@ -336,16 +336,6 @@ func openWinCertStore(provider, container string, issuers, intermediateIssuers [
 	}
 
 	return wcs, nil
-}
-
-// certContextToX509 creates an x509.Certificate from a Windows cert context.
-func certContextToX509(ctx *windows.CertContext) (*x509.Certificate, error) {
-	var der []byte
-	slice := (*reflect.SliceHeader)(unsafe.Pointer(&der))
-	slice.Data = uintptr(unsafe.Pointer(ctx.EncodedCert))
-	slice.Len = int(ctx.Length)
-	slice.Cap = int(ctx.Length)
-	return x509.ParseCertificate(append([]byte{}, der...))
 }
 
 // extractSimpleChain extracts the requested certificate chain from a CertSimpleChain.

--- a/certtostore_windows_go120.go
+++ b/certtostore_windows_go120.go
@@ -1,0 +1,37 @@
+//go:build windows && !go1.21
+// +build windows,!go1.21
+
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certtostore
+
+import (
+	"crypto/x509"
+
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// certContextToX509 creates an x509.Certificate from a Windows cert context.
+func certContextToX509(ctx *windows.CertContext) (*x509.Certificate, error) {
+	var der []byte
+	slice := (*reflect.SliceHeader)(unsafe.Pointer(&der))
+	slice.Data = uintptr(unsafe.Pointer(ctx.EncodedCert))
+	slice.Len = int(ctx.Length)
+	slice.Cap = int(ctx.Length)
+	return x509.ParseCertificate(append([]byte{}, der...))
+}

--- a/certtostore_windows_go121.go
+++ b/certtostore_windows_go121.go
@@ -1,0 +1,31 @@
+//go:build windows && go1.21
+// +build windows,go1.21
+
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certtostore
+
+import (
+	"crypto/x509"
+
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// certContextToX509 creates an x509.Certificate from a Windows cert context.
+func certContextToX509(ctx *windows.CertContext) (*x509.Certificate, error) {
+	return x509.ParseCertificate(append([]byte{}, unsafe.Slice(ctx.EncodedCert, ctx.Length)...))
+}


### PR DESCRIPTION
The relevant code is moved to build-tagged files depending on Go version, eventually the older one can go away.

Also it looks like my gopls-informed editor reordered imports.
