### PR TITLE
Add a way to iterate over cetificates in store

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -42,10 +42,10 @@ import (
 	"unsafe"
 
 	"github.com/google/deck"
-	"golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/cryptobyte"
-	"golang.org/x/sys/windows"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
 )
 
 // WinCertStorage provides windows-specific additions to the CertStorage interface.
@@ -438,8 +438,8 @@ func (w *WinCertStore) Cert() (*x509.Certificate, error) {
 // such as looking up the private key with CertKey().
 //
 // You must call FreeCertContext on the context after use.
-func (w *WinCertStore) CertWithContext() (*x509.Certificate, *windows.CertContext, error) {
-	c, ctx, err := w.cert(w.issuers, my, w.storeDomain())
+func (w *WinCertStore) CertWithContext(prev ...*windows.CertContext) (*x509.Certificate, *windows.CertContext, error) {
+	c, ctx, err := w.cert(w.issuers, my, w.storeDomain(), prev...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -455,13 +455,20 @@ func (w *WinCertStore) CertWithContext() (*x509.Certificate, *windows.CertContex
 
 // cert is a helper function to lookup certificates based on a known issuer.
 // store is used to specify which store to perform the lookup in (system or user).
-func (w *WinCertStore) cert(issuers []string, searchRoot *uint16, store uint32) (*x509.Certificate, *windows.CertContext, error) {
+func (w *WinCertStore) cert(issuers []string, searchRoot *uint16, store uint32, prevCtx ...*windows.CertContext) (*x509.Certificate, *windows.CertContext, error) {
 	h, err := w.storeHandle(store, searchRoot)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var prev *windows.CertContext
+
+	if len(prevCtx) == 1 {
+		prev = prevCtx[0]
+	} else {
+		return nil, nil, fmt.Errorf("up to one prevCtx can be provided")
+	}
+
 	var cert *x509.Certificate
 	for _, issuer := range issuers {
 		i, err := windows.UTF16PtrFromString(issuer)

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -465,8 +465,6 @@ func (w *WinCertStore) cert(issuers []string, searchRoot *uint16, store uint32, 
 
 	if len(prevCtx) == 1 {
 		prev = prevCtx[0]
-	} else {
-		return nil, nil, fmt.Errorf("up to one prevCtx can be provided")
 	}
 
 	var cert *x509.Certificate


### PR DESCRIPTION
If there is multiple certificates issued by same Issuer, only the first one is accessible.
This PR provides a way to iterate over certificates and choose the one to interact with.