### PR TITLE
Use correct data types for DWORD

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -42,10 +42,10 @@ import (
 	"unsafe"
 
 	"github.com/google/deck"
-	"golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/cryptobyte"
-	"golang.org/x/sys/windows"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
 )
 
 // WinCertStorage provides windows-specific additions to the CertStorage interface.
@@ -160,10 +160,10 @@ var (
 	nCryptProviderHandleProperty = wide("Provider Handle") // NCRYPT_PROV_HANDLE
 
 	// Flags for NCRYPT_IMPL_TYPE_PROPERTY
-	nCryptImplHardwareFlag    = 0x00000001 // NCRYPT_IMPL_HARDWARE_FLAG
-	nCryptImplSoftwareFlag    = 0x00000002 // NCRYPT_IMPL_SOFTWARE_FLAG
-	nCryptImplRemovableFlag   = 0x00000008 // NCRYPT_IMPL_REMOVABLE_FLAG
-	nCryptImplHardwareRngFlag = 0x00000010 // NCRYPT_IMPL_HARDWARE_RNG_FLAG
+	nCryptImplHardwareFlag    uint32 = 0x00000001 // NCRYPT_IMPL_HARDWARE_FLAG
+	nCryptImplSoftwareFlag    uint32 = 0x00000002 // NCRYPT_IMPL_SOFTWARE_FLAG
+	nCryptImplRemovableFlag   uint32 = 0x00000008 // NCRYPT_IMPL_REMOVABLE_FLAG
+	nCryptImplHardwareRngFlag uint32 = 0x00000010 // NCRYPT_IMPL_HARDWARE_RNG_FLAG
 
 	// curveIDs maps bcrypt key blob magic numbers to elliptic curves.
 	curveIDs = map[uint32]elliptic.Curve{
@@ -1220,7 +1220,7 @@ func keyMetadata(kh uintptr, store *WinCertStore) (*Key, error) {
 	defer freeObject(ph)
 
 	// get the provider implementation from the provider handle
-	impl, err := getPropertyInt(ph, nCryptImplTypeProperty)
+	impl, err := getPropertyUint32(ph, nCryptImplTypeProperty)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine provider implementation: %v", err)
 	}
@@ -1309,7 +1309,7 @@ func getPropertyHandle(kh uintptr, property *uint16) (uintptr, error) {
 	return **(**uintptr)(unsafe.Pointer(&buf)), nil
 }
 
-func getPropertyInt(kh uintptr, property *uint16) (int, error) {
+func getPropertyUint32(kh uintptr, property *uint16) (uint32, error) {
 	buf, err := fnGetProperty(kh, property)
 	if err != nil {
 		return 0, err
@@ -1317,7 +1317,7 @@ func getPropertyInt(kh uintptr, property *uint16) (int, error) {
 	if len(buf) < 1 {
 		return 0, fmt.Errorf("empty result")
 	}
-	return **(**int)(unsafe.Pointer(&buf)), nil
+	return **(**uint32)(unsafe.Pointer(&buf)), nil
 }
 
 func getPropertyStr(kh uintptr, property *uint16) (string, error) {

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -1232,7 +1232,7 @@ func keyMetadata(kh uintptr, store *WinCertStore) (*Key, error) {
 	// of the provider OpenWinCertStore was given. This means we cannot rely on
 	// store.Prov to tell us which provider a given key resides in. Instead, we
 	// lookup the provider directly from the key properties.
-	if impl == nCryptImplSoftwareFlag {
+	if (impl & nCryptImplSoftwareFlag) != 0 {
 		uc, lc, err = softwareKeyContainers(uc, store.storeDomain())
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, the code reads a property that is supposed to be a DWORD (ref: https://learn.microsoft.com/en-us/windows/win32/seccng/key-storage-property-identifiers#ncrypt_impl_type_property) using a cast to a golang `int` but those are only guaranteed to be "at least" 32 bits. This caused an issue where it was actually reading a 64-bit value and thus setting the upper 32 bits to undefined data.

This int/uint32 inconsistency is present in the "Chain resolution constants" as well (and possible elsewhere) but I didn't touch them in this PR.

This was then combined with the fact that the `nCryptImplSoftwareFlag` is compared using `==` and not with a mask, which would be more proper for a flag, caused the condition to incorrectly be evaluated to false.

I have changed the reading of the property to be a uint32 to match the spec. I changed the name of the reading function since it was only ever used there anyway and now it's clearer. I also changed the comparison to treat the field as a flag.
