### PR TITLE
Fix integer overflow

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -42,10 +42,10 @@ import (
 	"unsafe"
 
 	"github.com/google/deck"
-	"golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/cryptobyte"
-	"golang.org/x/sys/windows"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
 )
 
 // WinCertStorage provides windows-specific additions to the CertStorage interface.
@@ -1084,7 +1084,7 @@ func (w *WinCertStore) CertKey(cert *windows.CertContext) (*Key, error) {
 		return nil, fmt.Errorf("wrong mustFree [%d != 0]", mustFree)
 	}
 	if spec != ncryptKeySpec {
-		return nil, fmt.Errorf("wrong keySpec [%d != %d]", spec, ncryptKeySpec)
+		return nil, fmt.Errorf("wrong keySpec [%v != %v]", spec, ncryptKeySpec)
 	}
 
 	return keyMetadata(kh, w)

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -102,7 +102,6 @@ const (
 	compareShift            = 16                                              // CERT_COMPARE_SHIFT
 	findIssuerStr           = compareNameStrW<<compareShift | infoIssuerFlag  // CERT_FIND_ISSUER_STR_W
 	signatureKeyUsage       = 0x80                                            // CERT_DIGITAL_SIGNATURE_KEY_USAGE
-	ncryptKeySpec           = 0xFFFFFFFF                                      // CERT_NCRYPT_KEY_SPEC
 
 	// Legacy CryptoAPI flags
 	bCryptPadPKCS1 uintptr = 0x2
@@ -147,6 +146,7 @@ const (
 	certChainRevocationCheckCacheOnly = 0x80000000           // CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY
 )
 
+const ncryptKeySpec uint32 = 0xFFFFFFFF // CERT_NCRYPT_KEY_SPEC
 var (
 	// Key blob type constants.
 	bCryptRSAPublicBlob = wide("RSAPUBLICBLOB")
@@ -1084,7 +1084,7 @@ func (w *WinCertStore) CertKey(cert *windows.CertContext) (*Key, error) {
 		return nil, fmt.Errorf("wrong mustFree [%d != 0]", mustFree)
 	}
 	if spec != ncryptKeySpec {
-		return nil, fmt.Errorf("wrong keySpec [%v != %v]", spec, ncryptKeySpec)
+		return nil, fmt.Errorf("wrong keySpec [%d != %d]", spec, ncryptKeySpec)
 	}
 
 	return keyMetadata(kh, w)


### PR DESCRIPTION
Use %v as formatter instead of %d to prevent overflow on Windows ARM which treats int as 32 bit value.