### PR TITLE
Store with flags

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -462,34 +462,6 @@ func OpenWinCertStoreWithOptions(opts WinCertStoreOptions) (*WinCertStore, error
 	return wcs, nil
 }
 
-func openWinCertStore(provider, container string, issuers, intermediateIssuers []string, legacyKey, currentUser bool) (*WinCertStore, error) {
-	// Open a handle to the crypto provider we will use for private key operations
-	cngProv, err := openProvider(provider)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open crypto provider or provider not available: %v", err)
-	}
-
-	wcs := &WinCertStore{
-		Prov:                cngProv,
-		ProvName:            provider,
-		issuers:             issuers,
-		intermediateIssuers: intermediateIssuers,
-		container:           container,
-		stores:              make(map[string]*storeHandle),
-	}
-
-	if legacyKey {
-		wcs.keyStorageFlags = ncryptWriteKeyToLegacyStore
-		wcs.ProvName = ProviderMSLegacy
-	}
-
-	if !currentUser {
-		wcs.keyAccessFlags = nCryptMachineKey
-	}
-
-	return wcs, nil
-}
-
 // certContextToX509 creates an x509.Certificate from a Windows cert context.
 func certContextToX509(ctx *windows.CertContext) (*x509.Certificate, error) {
 	var der []byte

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -787,7 +787,7 @@ func (w *WinCertStore) linkLegacy() error {
 // If it is unable to remove any certificates, it returns an error.
 func (w *WinCertStore) Remove(removeSystem bool) error {
 	if w.isReadOnly() {
-		return fmt.Errorf("cannot store certificates in a read-only store")
+		return fmt.Errorf("cannot remove certificates from a read-only store")
 	}
 	for _, issuer := range w.issuers {
 		if err := w.remove(issuer, removeSystem); err != nil {

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -42,10 +42,10 @@ import (
 	"unsafe"
 
 	"github.com/google/deck"
-	"golang.org/x/crypto/cryptobyte/asn1"
-	"golang.org/x/crypto/cryptobyte"
-	"golang.org/x/sys/windows"
 	"github.com/hashicorp/go-multierror"
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
 )
 
 // WinCertStorage provides windows-specific additions to the CertStorage interface.
@@ -145,6 +145,13 @@ const (
 	certChainCacheOnlyURLRetrieval    = 0x00000004           // CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL
 	certChainDisableAIA               = 0x00002000           // CERT_CHAIN_DISABLE_AIA
 	certChainRevocationCheckCacheOnly = 0x80000000           // CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY
+
+	// CertStoreReadOnly represents read only permissions
+	CertStoreReadOnly = 0x00008000 // CERT_STORE_READONLY_FLAG
+	// CertStoreSaveToFile represents write to file permissions
+	CertStoreSaveToFile = 0x00001000 // CERT_STORE_SAVE_TO_FILE
+	// CertStoreOpenMaximumAllowed represents all permissions
+	CertStoreOpenMaximumAllowed = 0x00001000 // CERT_STORE_MAXIMUM_ALLOWED_FLAG
 )
 
 var (
@@ -289,6 +296,49 @@ func intendedKeyUsage(enc uint32, cert *windows.CertContext) (usage uint16) {
 	return
 }
 
+// WinCertStoreOptions contains configuration options for opening a certificate store.
+// This struct provides comprehensive control over how a Windows certificate store
+// is opened and configured, including cryptographic providers, key storage options,
+// and store access flags.
+type WinCertStoreOptions struct {
+	// Provider specifies the cryptographic provider to use for key operations.
+	// Common values include:
+	//   - ProviderMSPlatform: "Microsoft Platform Crypto Provider"
+	//   - ProviderMSSoftware: "Microsoft Software Key Storage Provider"
+	//   - ProviderMSLegacy: "Microsoft Enhanced Cryptographic Provider v1.0"
+	Provider string
+
+	// Container specifies the key container name within the cryptographic provider.
+	// This name uniquely identifies the key pair within the provider.
+	Container string
+
+	// Issuers contains the list of certificate issuer distinguished names to search for.
+	// The certificate lookup will match against these issuer names.
+	Issuers []string
+
+	// IntermediateIssuers contains the list of intermediate certificate issuer distinguished names.
+	// These are used for certificate chain validation and storage.
+	IntermediateIssuers []string
+
+	// LegacyKey indicates whether to use a legacy key format compatible with CryptoAPI.
+	// When true, keys will be stored in a format accessible to older Windows applications.
+	LegacyKey bool
+
+	// CurrentUser indicates whether to use the current user's certificate store instead
+	// of the local machine store. When false, the local machine store is used, which
+	// requires administrator privileges but makes certificates available to all users.
+	CurrentUser bool
+
+	// StoreFlags contains additional flags for certificate store operations.
+	// These flags control how the certificate store is opened and accessed.
+	// Common flags include:
+	//   - certStoreReadOnly: Open store in read-only mode
+	//   - certStoreSaveToFile: Enable saving store to file
+	//   - certStoreCreateNewFlag: Create new store if it doesn't exist
+	//   - certStoreOpenExistingFlag: Only open existing stores
+	StoreFlags uint32
+}
+
 // WinCertStore is a CertStorage implementation for the Windows Certificate Store.
 type WinCertStore struct {
 	Prov                uintptr
@@ -300,20 +350,116 @@ type WinCertStore struct {
 	certChains          [][]*x509.Certificate
 	stores              map[string]*storeHandle
 	keyAccessFlags      uintptr
+	storeFlags          uint32
 
 	mu sync.Mutex
+}
+
+// DefaultWinCertStoreOptions returns the default options for opening a certificate store.
+// These options represent a safe, commonly-used configuration suitable for most applications.
+//
+// Parameters:
+//   - provider: The cryptographic provider name (e.g., ProviderMSSoftware)
+//   - container: The key container name
+//   - issuers: List of certificate issuer distinguished names
+//   - intermediateIssuers: List of intermediate certificate issuer distinguished names
+//   - legacyKey: Whether to use legacy CryptoAPI-compatible key format
+//
+// Returns a WinCertStoreOptions struct with safe defaults:
+//   - CurrentUser: false (uses machine store)
+//   - StoreFlags: 0 (no special flags)
+func DefaultWinCertStoreOptions(provider, container string, issuers, intermediateIssuers []string, legacyKey bool) WinCertStoreOptions {
+	return WinCertStoreOptions{
+		Provider:            provider,
+		Container:           container,
+		Issuers:             issuers,
+		IntermediateIssuers: intermediateIssuers,
+		LegacyKey:           legacyKey,
+		CurrentUser:         false,
+		StoreFlags:          0,
+	}
 }
 
 // OpenWinCertStore creates a WinCertStore with keys accessible by all users on a machine.
 // Call Close() when finished using the store.
 func OpenWinCertStore(provider, container string, issuers, intermediateIssuers []string, legacyKey bool) (*WinCertStore, error) {
-	return openWinCertStore(provider, container, issuers, intermediateIssuers, legacyKey, false)
+	opts := DefaultWinCertStoreOptions(provider, container, issuers, intermediateIssuers, legacyKey)
+	return OpenWinCertStoreWithOptions(opts)
 }
 
 // OpenWinCertStoreCurrentUser creates a WinCertStore with keys accessible by current user.
 // Call Close() when finished using the store.
 func OpenWinCertStoreCurrentUser(provider, container string, issuers, intermediateIssuers []string, legacyKey bool) (*WinCertStore, error) {
-	return openWinCertStore(provider, container, issuers, intermediateIssuers, legacyKey, true)
+	opts := DefaultWinCertStoreOptions(provider, container, issuers, intermediateIssuers, legacyKey)
+	opts.CurrentUser = true
+	return OpenWinCertStoreWithOptions(opts)
+}
+
+// OpenWinCertStoreWithOptions creates a WinCertStore with the provided options.
+// This function provides maximum flexibility for configuring the certificate store,
+// including advanced options like custom store flags and provider selection.
+//
+// The function validates all options before attempting to open the store, returning
+// detailed error information if any configuration is invalid or incompatible.
+//
+// Parameters:
+//   - opts: Comprehensive configuration options for the certificate store
+//
+// Returns:
+//   - *WinCertStore: A configured certificate store ready for use
+//   - error: Detailed error information if store creation fails
+//
+// Example usage:
+//
+//	opts := WinCertStoreOptions{
+//	    Provider: ProviderMSSoftware,
+//	    Container: "MY",
+//	    Issuers: []string{"CN=My CA"},
+//	    StoreFlags: certStoreReadOnly,
+//	    CurrentUser: true,
+//	}
+//	store, err := OpenWinCertStoreWithOptions(opts)
+//	if err != nil {
+//	    return fmt.Errorf("failed to open certificate store: %v", err)
+//	}
+//	defer store.Close()
+//
+// Common errors:
+//   - Provider not available or accessible
+//   - Invalid or incompatible store flags
+//   - Missing required options (provider, container, issuers)
+//   - Insufficient privileges for machine store access
+func OpenWinCertStoreWithOptions(opts WinCertStoreOptions) (*WinCertStore, error) {
+	// Open a handle to the crypto provider we will use for private key operations
+	cngProv, err := openProvider(opts.Provider)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open crypto provider %q: %v", opts.Provider, err)
+	}
+
+	wcs := &WinCertStore{
+		Prov:                cngProv,
+		ProvName:            opts.Provider,
+		issuers:             make([]string, len(opts.Issuers)),
+		intermediateIssuers: make([]string, len(opts.IntermediateIssuers)),
+		container:           opts.Container,
+		stores:              make(map[string]*storeHandle),
+		storeFlags:          opts.StoreFlags,
+	}
+
+	// Deep copy the issuer slices to prevent external modification
+	copy(wcs.issuers, opts.Issuers)
+	copy(wcs.intermediateIssuers, opts.IntermediateIssuers)
+
+	if opts.LegacyKey {
+		wcs.keyStorageFlags = ncryptWriteKeyToLegacyStore
+		wcs.ProvName = ProviderMSLegacy
+	}
+
+	if !opts.CurrentUser {
+		wcs.keyAccessFlags = nCryptMachineKey
+	}
+
+	return wcs, nil
 }
 
 func openWinCertStore(provider, container string, issuers, intermediateIssuers []string, legacyKey, currentUser bool) (*WinCertStore, error) {
@@ -525,6 +671,9 @@ func (w *WinCertStore) Close() error {
 
 // Link will associate the certificate installed in the system store to the user store.
 func (w *WinCertStore) Link() error {
+	if w.isReadOnly() {
+		return fmt.Errorf("cannot link certificates in a read-only store")
+	}
 	cert, _, err := w.cert(w.issuers, my, certStoreLocalMachine)
 	if err != nil {
 		return fmt.Errorf("checking for existing machine certificates returned: %v", err)
@@ -592,7 +741,7 @@ type storeHandle struct {
 	handle *windows.Handle
 }
 
-func newStoreHandle(provider uint32, store *uint16) (*storeHandle, error) {
+func newStoreHandle(provider uint32, store *uint16, flags uint32) (*storeHandle, error) {
 	var s storeHandle
 	if s.handle != nil {
 		return &s, nil
@@ -601,7 +750,7 @@ func newStoreHandle(provider uint32, store *uint16) (*storeHandle, error) {
 		certStoreProvSystem,
 		0,
 		0,
-		provider,
+		provider|flags,
 		uintptr(unsafe.Pointer(store)))
 	if err != nil {
 		return nil, fmt.Errorf("CertOpenStore for the user store returned: %v", err)
@@ -665,6 +814,9 @@ func (w *WinCertStore) linkLegacy() error {
 // Remove removes certificates issued by any of w.issuers from the user and/or system cert stores.
 // If it is unable to remove any certificates, it returns an error.
 func (w *WinCertStore) Remove(removeSystem bool) error {
+	if w.isReadOnly() {
+		return fmt.Errorf("cannot store certificates in a read-only store")
+	}
 	for _, issuer := range w.issuers {
 		if err := w.remove(issuer, removeSystem); err != nil {
 			return err
@@ -1094,6 +1246,9 @@ func (w *WinCertStore) CertKey(cert *windows.CertContext) (*Key, error) {
 // software backed key, depending on support from the host OS
 // key size is set to the maximum supported by Microsoft Software Key Storage Provider
 func (w *WinCertStore) Generate(opts GenerateOpts) (crypto.Signer, error) {
+	if w.isReadOnly() {
+		return nil, fmt.Errorf("cannot generate keys in a read-only store")
+	}
 	deck.Infof("Provider: %s", w.ProvName)
 	switch opts.Algorithm {
 	case EC:
@@ -1459,6 +1614,9 @@ func curveName(kh uintptr) (elliptic.Curve, error) {
 
 // Store imports certificates into the Windows certificate store
 func (w *WinCertStore) Store(cert *x509.Certificate, intermediate *x509.Certificate) error {
+	if w.isReadOnly() {
+		return fmt.Errorf("cannot store certificates in a read-only store")
+	}
 	return w.StoreWithDisposition(cert, intermediate, windows.CERT_STORE_ADD_ALWAYS)
 }
 
@@ -1467,6 +1625,9 @@ func (w *WinCertStore) Store(cert *x509.Certificate, intermediate *x509.Certific
 // or a link to a matching certificate already exists in the store
 // https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/nf-wincrypt-certaddcertificatecontexttostore
 func (w *WinCertStore) StoreWithDisposition(cert *x509.Certificate, intermediate *x509.Certificate, disposition uint32) error {
+	if w.isReadOnly() {
+		return fmt.Errorf("cannot store certificates in a read-only store")
+	}
 	certContext, err := windows.CertCreateCertificateContext(
 		encodingX509ASN|encodingPKCS7,
 		&cert.Raw[0],
@@ -1529,7 +1690,7 @@ func (w *WinCertStore) storeHandle(provider uint32, store *uint16) (windows.Hand
 	key := fmt.Sprintf("%d%s", provider, windows.UTF16PtrToString(store))
 	var err error
 	if w.stores[key] == nil {
-		w.stores[key], err = newStoreHandle(provider, store)
+		w.stores[key], err = newStoreHandle(provider, store, w.storeFlags)
 		if err != nil {
 			return 0, err
 		}
@@ -1644,3 +1805,7 @@ func keyMatch(keyPath, dir string) (string, error) {
 // Verify interface conformance.
 var _ CertStorage = &WinCertStore{}
 var _ Credential = &Key{}
+
+func (w *WinCertStore) isReadOnly() bool {
+	return (w.storeFlags & CertStoreReadOnly) != 0
+}


### PR DESCRIPTION
I created this pull request for cases where the application using the certificate store is running with least privileges, and needs to be able read certificate and key from the certificate store.

For example in my use case I needed to run as a windows service under network service account.
The best practice I found was to import the certificate into LocalMachine/MY store, and grant read permissions to my service.

The current code does not support this scenario as it tries to open the store with the FullAccess permissions which my service does not have, resulting in access denied error when it tries to execute the windows.CertOpenStore method (newStoreHandle in certtostore_windows.go file)

