### PR TITLE
Do not return error if CAPI SW key is found but CNG is not locatable

### DIFF
--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -1745,9 +1745,6 @@ func softwareKeyContainers(uniqueID string, storeDomain uint32) (string, string,
 		if err != nil {
 			return "", "", fmt.Errorf("unable to locate CNG key: %v", err)
 		}
-		if cng == "" {
-			return "", "", errors.New("CNG key was empty")
-		}
 	default:
 		return "", "", fmt.Errorf("unexpected key type %q", keyType)
 	}

--- a/certtostore_windows.go
+++ b/certtostore_windows.go
@@ -335,6 +335,9 @@ type WinCertStoreOptions struct {
 	//   - certStoreCreateNewFlag: Create new store if it doesn't exist
 	//   - certStoreOpenExistingFlag: Only open existing stores
 	StoreFlags uint32
+
+	// IgnoreNoCNG can be set in order to ignore a not found CNG key when a CAPI key exists.
+	IgnoreNoCNG bool
 }
 
 // WinCertStore is a CertStorage implementation for the Windows Certificate Store.
@@ -349,6 +352,7 @@ type WinCertStore struct {
 	stores              map[string]*storeHandle
 	keyAccessFlags      uintptr
 	storeFlags          uint32
+	ignoreNoCNG         bool
 
 	mu sync.Mutex
 }
@@ -375,6 +379,7 @@ func DefaultWinCertStoreOptions(provider, container string, issuers, intermediat
 		LegacyKey:           legacyKey,
 		CurrentUser:         false,
 		StoreFlags:          0,
+		IgnoreNoCNG:         false,
 	}
 }
 
@@ -442,6 +447,7 @@ func OpenWinCertStoreWithOptions(opts WinCertStoreOptions) (*WinCertStore, error
 		container:           opts.Container,
 		stores:              make(map[string]*storeHandle),
 		storeFlags:          opts.StoreFlags,
+		ignoreNoCNG:         opts.IgnoreNoCNG,
 	}
 
 	// Deep copy the issuer slices to prevent external modification
@@ -1368,6 +1374,11 @@ func keyMetadata(kh uintptr, store *WinCertStore) (*Key, error) {
 		uc, lc, err = softwareKeyContainers(uc, store.storeDomain())
 		if err != nil {
 			return nil, err
+		}
+
+		if !store.ignoreNoCNG && uc == "" {
+			// key is not CNG backed, but store was opened with ignoreNoCNG=false
+			return nil, errors.New("CNG key was empty")
 		}
 	}
 


### PR DESCRIPTION
Hi

This PR is open for discussion. We have servers that include a CAPI software container, but do not have a CNG software container.

When the key of a certificate is requested (`CertKey` -> `keyMetadata` -> `softwareKeyContainers`), the process fails with `CNG key was empty` if the CNG key is not present, even though the CAPI key is found correctly.

According to [Win32 / CNG / Key Storage and Retrieval](https://learn.microsoft.com/en-us/windows/win32/seccng/key-storage-and-retrieval#key-directories-and-files), the application API prefers CNG and then falls back to CAPI. Therefore, a CNG key is not always expected to be available:

> When an application attempts to open an existing persisted key, CNG first attempts to open the native CNG file. If this file does not exist, then CNG attempts to locate a matching key in the legacy CryptoAPI key container.

I propose to not return an error if the CNG key is not found but the CAPI key is present. In this case, the CNG path would simply not be populated, similar to how the CAPI path is omitted when its key is not found in `softwareKeyContainers`.

I am unsure if this change would have any implications, such as breaking changes, so feedback is appreciated.